### PR TITLE
histogram: buckets are cumulative

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -45,9 +45,9 @@ func Example() {
 	// http_request_seconds_bucket{status="200",le="0.1"} 0
 	// http_request_seconds_bucket{status="200",le="0.5"} 0
 	// http_request_seconds_bucket{status="200",le="1"} 1
-	// http_request_seconds_bucket{status="200",le="5"} 0
-	// http_request_seconds_bucket{status="200",le="10"} 0
-	// http_request_seconds_bucket{status="200",le="+Inf"} 0
+	// http_request_seconds_bucket{status="200",le="5"} 1
+	// http_request_seconds_bucket{status="200",le="10"} 1
+	// http_request_seconds_bucket{status="200",le="+Inf"} 1
 	// http_request_seconds_count{status="200"} 1
 	// http_request_seconds_sum{status="200"} 0.56
 	// http_request_seconds_created{status="200"} 1515151515.757576

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -216,12 +216,12 @@ func TestHistogram_AppendPoints(t *testing.T) {
 		{
 			Suffix: SuffixBucket,
 			Label:  Label{Name: "le", Value: "2"},
-			Value:  1,
+			Value:  2,
 		},
 		{
 			Suffix: SuffixBucket,
 			Label:  Label{Name: "le", Value: "+Inf"},
-			Value:  0,
+			Value:  2,
 		},
 		{Suffix: SuffixCount, Value: 2},
 		{Suffix: SuffixSum, Value: 1.9},

--- a/omhttp/omhttp_example_test.go
+++ b/omhttp/omhttp_example_test.go
@@ -79,17 +79,17 @@ func ExampleInstrument() {
 	// # UNIT http_requests_seconds seconds
 	// http_requests_seconds_bucket{path="/missing",status="404",le="0.1"} 0
 	// http_requests_seconds_bucket{path="/missing",status="404",le="0.2"} 1
-	// http_requests_seconds_bucket{path="/missing",status="404",le="0.5"} 0
-	// http_requests_seconds_bucket{path="/missing",status="404",le="1"} 0
-	// http_requests_seconds_bucket{path="/missing",status="404",le="+Inf"} 0
+	// http_requests_seconds_bucket{path="/missing",status="404",le="0.5"} 1
+	// http_requests_seconds_bucket{path="/missing",status="404",le="1"} 1
+	// http_requests_seconds_bucket{path="/missing",status="404",le="+Inf"} 1
 	// http_requests_seconds_count{path="/missing",status="404"} 1
 	// http_requests_seconds_sum{path="/missing",status="404"} 0.187
 	// http_requests_seconds_created{path="/missing",status="404"} 1515151515.757576
 	// http_requests_seconds_bucket{path="/home",status="200",le="0.1"} 0
 	// http_requests_seconds_bucket{path="/home",status="200",le="0.2"} 1
-	// http_requests_seconds_bucket{path="/home",status="200",le="0.5"} 0
-	// http_requests_seconds_bucket{path="/home",status="200",le="1"} 0
-	// http_requests_seconds_bucket{path="/home",status="200",le="+Inf"} 0
+	// http_requests_seconds_bucket{path="/home",status="200",le="0.5"} 1
+	// http_requests_seconds_bucket{path="/home",status="200",le="1"} 1
+	// http_requests_seconds_bucket{path="/home",status="200",le="+Inf"} 1
 	// http_requests_seconds_count{path="/home",status="200"} 1
 	// http_requests_seconds_sum{path="/home",status="200"} 0.187
 	// http_requests_seconds_created{path="/home",status="200"} 1515151515.757576

--- a/registry_test.go
+++ b/registry_test.go
@@ -129,20 +129,20 @@ func TestRegistry_Histogram(t *testing.T) {
 	checkOutput(t, reg, `
 		# TYPE foo histogram
 		foo_bucket{a="b",le="0.01"} 32
-		foo_bucket{a="b",le="0.1"} 25 # {} 0.054
-		foo_bucket{a="b",le="1"} 32 # {trace_id="KOO5S4vxi0o"} 0.67
-		foo_bucket{a="b",le="10"} 10 # {trace_id="oHg5SJYRHA0"} 9.8 1515151515
-		foo_bucket{a="b",le="100"} 4
-		foo_bucket{a="b",le="+Inf"} 0
+		foo_bucket{a="b",le="0.1"} 57 # {} 0.054
+		foo_bucket{a="b",le="1"} 89 # {trace_id="KOO5S4vxi0o"} 0.67
+		foo_bucket{a="b",le="10"} 99 # {trace_id="oHg5SJYRHA0"} 9.8 1515151515
+		foo_bucket{a="b",le="100"} 103
+		foo_bucket{a="b",le="+Inf"} 103
 		foo_count{a="b"} 103
 		foo_sum{a="b"} 240.40971549095673
 		foo_created{a="b"} 1515151515.757576
 		foo_bucket{le="0.01"} 39
-		foo_bucket{le="0.1"} 27
-		foo_bucket{le="1"} 21
-		foo_bucket{le="10"} 8
-		foo_bucket{le="100"} 4
-		foo_bucket{le="+Inf"} 1
+		foo_bucket{le="0.1"} 66
+		foo_bucket{le="1"} 87
+		foo_bucket{le="10"} 95
+		foo_bucket{le="100"} 99
+		foo_bucket{le="+Inf"} 100
 		foo_count 100
 		foo_sum 320.0575197521944
 		foo_created 1515151515.757576


### PR DESCRIPTION
https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram

> Buckets MUST be cumulative. As an example for a metric representing request latency in seconds its values for buckets with thresholds 1, 2, 3, and +Inf MUST follow value_1 <= value_2 <= value_3 <= value_+Inf. If ten requests took 1 second each, the values of the 1, 2, 3, and +Inf buckets MUST equal 10.