### PR TITLE
Gauge: make it Add-able right after init

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
           check-latest: true
           cache: true
       - uses: golangci/golangci-lint-action@v3
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.19.x, 1.20.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -45,6 +45,23 @@ func TestGauge(t *testing.T) {
 	}
 }
 
+func TestGaugeAdd(t *testing.T) {
+	met := NewGauge(GaugeOptions{})
+
+	// make sure it's safe to be used right after creation (without any Set-s)
+	met.Add(42)
+	if exp, got := 42.0, met.Value(); exp != got {
+		t.Fatalf("expected %v, got %v", exp, got)
+	}
+
+	// and after reset
+	met.Reset(GaugeOptions{})
+	met.Add(21)
+	if exp, got := 21.0, met.Value(); exp != got {
+		t.Fatalf("expected %v, got %v", exp, got)
+	}
+}
+
 func TestGauge_AppendPoints(t *testing.T) {
 	met := NewGauge(GaugeOptions{})
 	if got, err := met.AppendPoints(nil, &mockDesc); err != nil {


### PR DESCRIPTION
It is initialized with NaN value, so Add-s don't work unless you Set(0) first.